### PR TITLE
Pin maven version to 3.6.1

### DIFF
--- a/.github/workflows/build-on-push.yaml
+++ b/.github/workflows/build-on-push.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4
         with:
-          maven-version: 3.5.4
+          maven-version: 3.6.1
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml

--- a/.github/workflows/build-on-push.yaml
+++ b/.github/workflows/build-on-push.yaml
@@ -22,9 +22,9 @@ jobs:
           restore-keys: ${{ runner.os }}-m2
 
       - name: Set up Maven
-        uses: aahmed-se/setup-maven@v3
+        uses: stCarolas/setup-maven@v4
         with:
-          maven-version: 3.6.1
+          maven-version: 3.5.4
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml

--- a/.github/workflows/build-on-push.yaml
+++ b/.github/workflows/build-on-push.yaml
@@ -21,6 +21,11 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
+      - name: Set up Maven
+        uses: aahmed-se/setup-maven@v3
+        with:
+          maven-version: 3.6.1
+
       - name: Build with Maven
         run: mvn -B package --file pom.xml
 

--- a/.github/workflows/on_release_tag_created.yaml
+++ b/.github/workflows/on_release_tag_created.yaml
@@ -26,6 +26,11 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4
+        with:
+          maven-version: 3.6.1
+
       - name: Get Version from Tag
         id: get_version
         uses: battila7/get-version-action@v2


### PR DESCRIPTION
Because maven 3.8 doesn't allow for HTTP repositories, such as our upstream 4th line repo